### PR TITLE
OPS-1289 - npm org name change

### DIFF
--- a/.github/workflows/pr-automation-comment-reaction.yml
+++ b/.github/workflows/pr-automation-comment-reaction.yml
@@ -10,7 +10,7 @@ jobs:
       - name: listen for PR Comments
         uses: machine-learning-apps/actions-chatops@master
         with:
-          TRIGGER_PHRASE: "@schul-cloud-bot tell dependabot to recreate PR"
+          TRIGGER_PHRASE: "@hpi-schul-cloud-bot tell dependabot to recreate PR"
         env:
           GITHUB_TOKEN: ${{ secrets.SC_BOT_GITHUB_TOKEN }}
         id: prcomm

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -28,14 +28,14 @@ pull_request_rules:
       label:
         remove:
           - ready to merge
-  - name: let @schul-cloud-bot recreate dependabot PRs with conflicts
+  - name: let @hpi-schul-cloud-bot recreate dependabot PRs with conflicts
     conditions:
       - author~=dependabot(-preview)?\[bot\]
       - label~=dependencies
       - conflict
     actions:
       comment:
-        message: "@schul-cloud-bot tell dependabot to recreate PR"
+        message: "@hpi-schul-cloud-bot tell dependabot to recreate PR"
   #######################
   # AUTO MERGING
   #######################

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
     - script: skip
       name: GITHUB
       before_deploy:
-        - echo -e "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGE_TOKEN}\nregistry=https://npm.pkg.github.com/schul-cloud" > .npmrc 2> /dev/null
+        - echo -e "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGE_TOKEN}\nregistry=https://npm.pkg.github.com/hpi-schul-cloud" > .npmrc 2> /dev/null
       deploy:
         provider: script
         script:

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-<h1 align="center">schul-cloud lint</h1>
+<h1 align="center">hpi-schul-cloud lint</h1>
 
-[![Build Status](https://travis-ci.com/schul-cloud/lint-configs.svg?branch=master)](https://travis-ci.com/schul-cloud/lint-configs)
-[![Mergify badge](https://img.shields.io/endpoint.svg?url=https://dashboard.mergify.io/badges/schul-cloud/lint-configs&style=flat)](https://mergify.io)
+[![Build Status](https://travis-ci.com/hpi-schul-cloud/lint-configs.svg?branch=master)](https://travis-ci.com/hpi-schul-cloud/lint-configs)
+[![Mergify badge](https://img.shields.io/endpoint.svg?url=https://dashboard.mergify.io/badges/hpi-schul-cloud/lint-configs&style=flat)](https://mergify.io)
 
 # About
 
 This repo contains several packages to develop and build clean projects.
 
-- [@schul-cloud/eslint-config](./packages/eslint-config) - This repository contains shareable ESLint configurations used by the applications at @schul-cloud.
-  - [![npm (scoped)](https://img.shields.io/npm/v/@schul-cloud/eslint-config)](https://www.npmjs.com/package/@schul-cloud/eslint-config)
-- [@schul-cloud/prettier-config](./packages/prettier-config) - This repository contains a shareable Prettier configuration used by the applications at @schul-cloud.
-  - [![npm (scoped)](https://img.shields.io/npm/v/@schul-cloud/prettier-config)](https://www.npmjs.com/package/@schul-cloud/prettier-config)
-- [@schul-cloud/stylelint-config](./packages/stylelint-config) - This repository contains a shareable Stylelint configuration used by the applications at @schul-cloud.
-  - [![npm (scoped)](https://img.shields.io/npm/v/@schul-cloud/stylelint-config)](https://www.npmjs.com/package/@schul-cloud/stylelint-config)
+- [@hpi-schul-cloud/eslint-config](./packages/eslint-config) - This repository contains shareable ESLint configurations used by the applications at @hpi-schul-cloud.
+  - [![npm (scoped)](https://img.shields.io/npm/v/@hpi-schul-cloud/eslint-config)](https://www.npmjs.com/package/@hpi-schul-cloud/eslint-config)
+- [@hpi-schul-cloud/prettier-config](./packages/prettier-config) - This repository contains a shareable Prettier configuration used by the applications at @hpi-schul-cloud.
+  - [![npm (scoped)](https://img.shields.io/npm/v/@hpi-schul-cloud/prettier-config)](https://www.npmjs.com/package/@hpi-schul-cloud/prettier-config)
+- [@hpi-schul-cloud/stylelint-config](./packages/stylelint-config) - This repository contains a shareable Stylelint configuration used by the applications at @hpi-schul-cloud.
+  - [![npm (scoped)](https://img.shields.io/npm/v/@hpi-schul-cloud/stylelint-config)](https://www.npmjs.com/package/@hpi-schul-cloud/stylelint-config)
 
 # How to use it
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "schul-cloud",
+  "name": "hpi-schul-cloud",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "schul-cloud",
+  "name": "hpi-schul-cloud",
   "license": "AGPL-3.0",
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/schul-cloud/lint-configs"
+    "url": "https://github.com/hpi-schul-cloud/lint-configs"
   },
-  "author": "HPI Schul-cloud (https://schul-cloud.org)",
-  "homepage": "https://github.com/schul-cloud/lint-configs#readme",
+  "author": "HPI Schul-cloud (https://hpi-schul-cloud.de)",
+  "homepage": "https://github.com/hpi-schul-cloud/lint-configs#readme",
   "bugs": {
-    "url": "https://github.com/schul-cloud/lint-configs/issues"
+    "url": "https://github.com/hpi-schul-cloud/lint-configs/issues"
   },
   "devDependencies": {
     "lerna": "^3.16.4"

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,8 +1,8 @@
-# @schul-cloud/eslint-config
+# @hpi-schul-cloud/eslint-config
 
-This package contains shareable ESLint configuration used by the @schul-cloud applications.
+This package contains shareable ESLint configuration used by the @hpi-schul-cloud applications.
 
-[![npm (scoped)](https://img.shields.io/npm/v/@schul-cloud/eslint-config)](https://www.npmjs.com/package/@schul-cloud/eslint-config)
+[![npm (scoped)](https://img.shields.io/npm/v/@hpi-schul-cloud/eslint-config)](https://www.npmjs.com/package/@hpi-schul-cloud/eslint-config)
 
 ## Getting Started
 
@@ -11,25 +11,25 @@ This package contains shareable ESLint configuration used by the @schul-cloud ap
 Using npm:
 
 ```shell
-  npm install @schul-cloud/eslint-config --save-dev
+  npm install @hpi-schul-cloud/eslint-config --save-dev
 ```
 
 Using Yarn:
 
 ```shell
-  yarn add @schul-cloud/eslint-config --dev
+  yarn add @hpi-schul-cloud/eslint-config --dev
 ```
 
 ### 2. Usage
 
 * Create a new file and name it as `.eslintrc.js`
-* Import relevant config file from `@schul-cloud/eslint-config` and just export it as follows.
+* Import relevant config file from `@hpi-schul-cloud/eslint-config` and just export it as follows.
 
 ### For JavaScript projects
 
 ```javascript
 module.exports = {
-  extends: '@schul-cloud/eslint-config/javascript',
+  extends: '@hpi-schul-cloud/eslint-config/javascript',
 };
 ```
 
@@ -37,7 +37,7 @@ module.exports = {
 
 ```javascript
 module.exports = {
-  extends: '@schul-cloud/eslint-config/javascriptVue',
+  extends: '@hpi-schul-cloud/eslint-config/javascriptVue',
 };
 ```
 
@@ -51,7 +51,7 @@ module.exports = {
   overrides: [
     {
       files: ["**/*.unit.js"], // regex that matches your testfiles
-      extends: ["@schul-cloud/eslint-config/javascriptJest"],
+      extends: ["@hpi-schul-cloud/eslint-config/javascriptJest"],
     },
   ],
 };
@@ -65,7 +65,7 @@ If you want to override the default configuration, then add the following code i
 
 ```javascript
 module.exports = {
-  extends: '@schul-cloud/eslint-config/javascript',
+  extends: '@hpi-schul-cloud/eslint-config/javascript',
   // your config options goes here, e.g. plugins: [...], rules: { ... }
 };
 ```
@@ -74,7 +74,7 @@ module.exports = {
 
 ```javascript
 module.exports = {
-  extends: '@schul-cloud/eslint-config/javascriptVue',
+  extends: '@hpi-schul-cloud/eslint-config/javascriptVue',
   // your config options goes here, e.g. plugins: [...], rules: { ... }
 };
 ```
@@ -87,7 +87,7 @@ module.exports = {
   overrides: [
     {
       files: ["**/*.unit.js"], // regex that matches your testfiles
-      extends: ["@schul-cloud/eslint-config/javascriptJest"],
+      extends: ["@hpi-schul-cloud/eslint-config/javascriptJest"],
       rules: {
         // you can adjust the rules here.
       },

--- a/packages/eslint-config/package-lock.json
+++ b/packages/eslint-config/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schul-cloud/eslint-config",
+  "name": "@hpi-schul-cloud/eslint-config",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/hpi-schul-cloud/lint-configs"
   },
-  "author": "HPI schul-cloud (https://hpi-schul-cloud.de)",
+  "author": "HPI Schul-Cloud (https://hpi-schul-cloud.de)",
   "license": "AGPL-3.0",
   "engines": {
     "node": ">=10",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,26 +1,26 @@
 {
-  "name": "@schul-cloud/eslint-config",
+  "name": "@hpi-schul-cloud/eslint-config",
   "version": "1.0.0",
-  "description": "This package contains shareable ESLint configuration used by the applications @schul-cloud.",
+  "description": "This package contains shareable ESLint configuration used by the applications @hpi-schul-cloud.",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/schul-cloud/lint-configs"
+    "url": "https://github.com/hpi-schul-cloud/lint-configs"
   },
-  "author": "HPI Schul-cloud (https://schul-cloud.org)",
+  "author": "HPI schul-cloud (https://hpi-schul-cloud.de)",
   "license": "AGPL-3.0",
   "engines": {
     "node": ">=10",
     "npm": ">=6"
   },
   "bugs": {
-    "url": "https://github.com/schul-cloud/lint-configs/issues"
+    "url": "https://github.com/hpi-schul-cloud/lint-configs/issues"
   },
-  "homepage": "https://www.npmjs.com/package/@schul-cloud/eslint-config",
+  "homepage": "https://www.npmjs.com/package/@hpi-schul-cloud/eslint-config",
   "keywords": [
     "eslint",
     "formatting",
-    "schul-cloud"
+    "hpi-schul-cloud"
   ],
   "dependencies": {
     "@babel/core": "^7.12.3",

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,6 +1,6 @@
-# @schul-cloud/prettier-config
+# @hpi-schul-cloud/prettier-config
 
-[![npm (scoped)](https://img.shields.io/npm/v/@schul-cloud/prettier-config)](https://www.npmjs.com/package/@schul-cloud/prettier-config)
+[![npm (scoped)](https://img.shields.io/npm/v/@hpi-schul-cloud/prettier-config)](https://www.npmjs.com/package/@hpi-schul-cloud/prettier-config)
 
 ## Getting Started
 
@@ -9,29 +9,29 @@
 Using npm:
 
 ```shell
-  npm install @schul-cloud/prettier-config --save-dev
+  npm install @hpi-schul-cloud/prettier-config --save-dev
 ```
 
 Using Yarn:
 
 ```shell
-  yarn add @schul-cloud/prettier-config --dev
+  yarn add @hpi-schul-cloud/prettier-config --dev
 ```
 
 
 ### 2. Usage
 
 * Create a new file and name it as `prettier.config.js`
-* Just import `@schul-cloud/prettier-config` and export it.
+* Just import `@hpi-schul-cloud/prettier-config` and export it.
 
 ```javascript
-module.exports = require('@schul-cloud/prettier-config');
+module.exports = require('@hpi-schul-cloud/prettier-config');
 ```
 
 * In order to have a `.prettierignore` file as well, just run the following command from terminal:
 
 ```sh
-  cat ./node_modules/@schul-cloud/prettier-config/.prettierignore >> .prettierignore
+  cat ./node_modules/@hpi-schul-cloud/prettier-config/.prettierignore >> .prettierignore
 ```
 
 ## Override Default Config
@@ -39,7 +39,7 @@ module.exports = require('@schul-cloud/prettier-config');
 If you want to override the default configuration, then add the following code in `prettier.config.js` file:
 
 ```javascript
-  const prettierConfig = require('@schul-cloud/prettier-config');
+  const prettierConfig = require('@hpi-schul-cloud/prettier-config');
   module.exports = {
     ...prettierConfig,
     // your config options goes here, e.g. printWidth: 80

--- a/packages/prettier-config/package-lock.json
+++ b/packages/prettier-config/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schul-cloud/prettier-config",
+  "name": "@hpi-schul-cloud/prettier-config",
   "version": "1.0.0",
   "lockfileVersion": 1
 }

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@schul-cloud/prettier-config",
+  "name": "@hpi-schul-cloud/prettier-config",
   "version": "1.0.0",
-  "description": "This package contains shareable Prettier configuration used by the applications created @schul-cloud.",
+  "description": "This package contains shareable Prettier configuration used by the applications created @hpi-schul-cloud.",
   "main": "index.js",
-  "author": "HPI Schul-cloud (https://schul-cloud.org)",
+  "author": "HPI schul-cloud (https://hpi-schul-cloud.de)",
   "license": "AGPL-3.0",
   "private": false,
   "engines": {
@@ -12,17 +12,17 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/schul-cloud/lint-configs"
+    "url": "https://github.com/hpi-schul-cloud/lint-configs"
   },
   "bugs": {
-    "url": "https://github.com/schul-cloud/lint-configs/issues"
+    "url": "https://github.com/hpi-schul-cloud/lint-configs/issues"
   },
   "keywords": [
     "prettier",
     "formatting",
-    "schul-cloud"
+    "hpi-schul-cloud"
   ],
-  "homepage": "https://www.npmjs.com/package/@schul-cloud/prettier-config",
+  "homepage": "https://www.npmjs.com/package/@hpi-schul-cloud/prettier-config",
   "peerDependencies": {
     "prettier": ">=2.0.5"
   },

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -1,6 +1,6 @@
-# @schul-cloud/stylelint-config
+# @hpi-schul-cloud/stylelint-config
 
-[![npm (scoped)](https://img.shields.io/npm/v/@schul-cloud/stylelint-config)](https://www.npmjs.com/package/@schul-cloud/stylelint-config)
+[![npm (scoped)](https://img.shields.io/npm/v/@hpi-schul-cloud/stylelint-config)](https://www.npmjs.com/package/@hpi-schul-cloud/stylelint-config)
 
 ## Getting Started
 
@@ -9,20 +9,20 @@
 Using npm:
 
 ```shell
-  npm install -D @schul-cloud/stylelint-config
+  npm install -D @hpi-schul-cloud/stylelint-config
 ```
 
 Using Yarn:
 
 ```shell
-  yarn add @schul-cloud/stylelint-config --dev
+  yarn add @hpi-schul-cloud/stylelint-config --dev
 ```
 
 
 ### 2. Usage
 
 * Create a new file and name it as `stylelint.config.js`
-* Just extend `@schul-cloud/stylelint-config`
+* Just extend `@hpi-schul-cloud/stylelint-config`
 
 ```javascript
 {

--- a/packages/stylelint-config/package-lock.json
+++ b/packages/stylelint-config/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schul-cloud/stylelint-config",
+  "name": "@hpi-schul-cloud/stylelint-config",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@schul-cloud/stylelint-config",
+  "name": "@hpi-schul-cloud/stylelint-config",
   "version": "1.0.0",
-  "description": "This package contains shareable Stylelint configuration used by the applications created @schul-cloud.",
+  "description": "This package contains shareable Stylelint configuration used by the applications created @hpi-schul-cloud.",
   "main": "index.js",
-  "author": "HPI Schul-cloud (https://schul-cloud.org)",
+  "author": "HPI schul-cloud (https://hpi-schul-cloud.de)",
   "license": "AGPL-3.0",
   "private": false,
   "engines": {
@@ -12,17 +12,17 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/schul-cloud/lint-configs"
+    "url": "https://github.com/hpi-schul-cloud/lint-configs"
   },
   "bugs": {
-    "url": "https://github.com/schul-cloud/lint-configs/issues"
+    "url": "https://github.com/hpi-schul-cloud/lint-configs/issues"
   },
   "keywords": [
     "stylelint",
     "formatting",
-    "schul-cloud"
+    "hpi-schul-cloud"
   ],
-  "homepage": "https://www.npmjs.com/package/@schul-cloud/stylelint-config",
+  "homepage": "https://www.npmjs.com/package/@hpi-schul-cloud/stylelint-config",
   "peerDependencies": {
     "stylelint": ">=13.3.3"
   },


### PR DESCRIPTION
# Description
 - This pullrequest change the NPM Organisation name to hpi-schul-cloud
## Links to Tickets or other pull requests
 - https://ticketsystem.hpi-schul-cloud.org/browse/OPS-1289
## Changes
 - Name of the NPM Organisation

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
 - only name change to hpi-schul-cloud

## Deployment
 - with the next styl release
## New Repos, NPM pakages or vendor scripts
 - new NPM Organisation name
## Screenshots of UI changes
 - No UI changes

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
